### PR TITLE
Add dependencies to code path

### DIFF
--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -204,10 +204,16 @@ make_command_string(State, App, EdocOutDir, Opts) ->
         output_dir(App, Opts),
         "--quiet"
     ],
+    DepPaths = rebar_state:code_paths(State, all_deps),
+    PathArgs = lists:foldl(
+        fun(Path, Args) -> ["--paths", Path | Args] end,
+        [],
+        DepPaths
+    ),
     Optionals = [canonical, language, logo, formatter],
     CommandArgs = lists:foldl(
         fun(Opt, Args) -> Args ++ maybe_add_opt(Opt, Opts) end,
-        BaseArgs,
+        BaseArgs ++ PathArgs,
         Optionals
     ),
     string:join(CommandArgs, " ").


### PR DESCRIPTION
Add the `ebin` directories of dependencies to the code path using `ex_doc`'s `--paths` option.  Otherwise, if `foo.erl` references `dep:type/0`, this results in the following warning:

```
warning: documentation references type "dep:type/0" but it is undefined or private
  src/foo.erl:37: dep.type/0
```