### PR TITLE
Tweak expectations for rebar.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Simply add the configuration below to your `rebar.config` and adjust for your pr
 
 ```erlang
 {ex_doc, [
-     {extras, [<<"README.md">>, <<"LICENSE">>]},
-     {main, <<"readme">>},
+     {extras, ["README.md", "LICENSE"]},
+     {main, "README.md"},
      {source_url, <<"https://github.com/namespace/your_app">>}
 ]}.
 ```
@@ -56,11 +56,11 @@ For further customization, see the configuration for `rebar3_ex_doc`:
 ```erlang
 {ex_doc, [
     {extras, [
-          {'CHANGELOG.md', #{title => <<"Changelog">>}},
-          {'README.md', #{title => <<"Overview">>}},
-          {'LICENSE.md', #{title => <<"License">>}}
+          {"CHANGELOG.md", #{title => "Changelog"}},
+          {"README.md", #{title => "Overview"}},
+          {"LICENSE.md", #{title => "License"}}
     ]},
-    {main, <<"readme">>},
+    {main, "README.md"},
     {source_url, <<"https://github.com/starbelly/rebar3_ex_doc">>},
     {assets, <<"assets">>},
     {api_reference, false}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Simply add the configuration below to your `rebar.config` and adjust for your pr
 {ex_doc, [
      {extras, ["README.md", "LICENSE"]},
      {main, "README.md"},
-     {source_url, <<"https://github.com/namespace/your_app">>}
+     {source_url_pattern, "https://github.com/namespace/your_app"}
 ]}.
 ```
 
@@ -61,8 +61,8 @@ For further customization, see the configuration for `rebar3_ex_doc`:
           {"LICENSE.md", #{title => "License"}}
     ]},
     {main, "README.md"},
-    {source_url, <<"https://github.com/starbelly/rebar3_ex_doc">>},
-    {assets, <<"assets">>},
+    {source_url_pattern, "https://github.com/starbelly/rebar3_ex_doc"},
+    {assets, "assets"},
     {api_reference, false}
 ]}.
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Simply add the configuration below to your `rebar.config` and adjust for your pr
 {ex_doc, [
      {extras, ["README.md", "LICENSE"]},
      {main, "README.md"},
-     {source_url_pattern, "https://github.com/namespace/your_app"}
+     {source_url, "https://github.com/namespace/your_app"}
 ]}.
 ```
 
@@ -61,7 +61,7 @@ For further customization, see the configuration for `rebar3_ex_doc`:
           {"LICENSE.md", #{title => "License"}}
     ]},
     {main, "README.md"},
-    {source_url_pattern, "https://github.com/starbelly/rebar3_ex_doc"},
+    {source_url, "https://github.com/starbelly/rebar3_ex_doc"},
     {assets, "assets"},
     {api_reference, false}
 ]}.
@@ -92,6 +92,11 @@ To integrate with `rebar3_hex` merely specify `rebar3_ex_doc` as the doc provide
     {doc, #{provider => ex_doc}}
 ]}.
 ```
+
+### Supported options
+
+Not all `ex_doc` options are supported. This means we'll warn on unknown options, but still pass them to `ex_doc`. We try to make sure the supported options are converted to the format known by `ex_doc`.
+In case you get a warning for something that is working or would like further conversion support, open a [GitHub issue](https://github.com/starbelly/rebar3_ex_doc/issues).
 
 # Development
 

--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -254,35 +254,88 @@ ex_doc_config_file(App, EdocOutDir) ->
 
 to_ex_doc_format(ExDocOpts) ->
     lists:foldl(
-        fun ({main, Main}, Opts) ->
-                [{main, to_lower_binary(filename:rootname(Main))} | Opts];
-            ({logo, Logo}, Opts) ->
-                [{logo, to_binary(Logo)} | Opts];
-            ({extras, ExDocOptsExtras}, Opts) ->
-                [{extras,
-                  lists:foldl(
-                      fun ({Extra, ExtraOpts}, Extras) ->
-                              [{to_atom(Extra), to_ex_doc_format_extras(ExtraOpts)} | Extras];
-                          (Extra, Extras) when is_list(Extra) ->
-                              [to_binary(Extra) | Extras];
-                          (OtherExtra, Extras) -> % unknown: leaving as is
-                              [OtherExtra | Extras]
-                      end,
-                      [],
-                      ExDocOptsExtras
-                  )} | Opts];
-            (OtherOpts, Opts) -> % unknown: leaving as is
-                [OtherOpts | Opts]
+        fun ({authors = K, Authors}, Opts) ->
+                [{K, [to_binary(Author) || Author <- Authors]} | Opts];
+            ({deps = K, Deps}, Opts) ->
+                [{K, maps:map(
+                         fun (_DepName, DepDocURL) ->
+                             to_binary(DepDocURL)
+                         end,
+                         Deps
+                     )} | Opts];
+            ({extras = K, Extras}, Opts) ->
+                [{K, to_ex_doc_format_extras(Extras)} | Opts];
+            ({filter_modules = K, FilterModules}, Opts) ->
+                [{K, [to_ex_doc_format_filter_module(FilterModule) || FilterModule <- FilterModules]} | Opts];
+            ({formatters = K, Formatters}, Opts) ->
+                [{K, [to_binary(Formatter) || Formatter <- Formatters]} | Opts];
+            ({groups_for_extras = K, GroupsForExtras}, Opts) ->
+                [{K, to_ex_doc_format_groups_for_extras(GroupsForExtras)} | Opts];
+            ({main = K, Main}, Opts) ->
+                [{K, to_lower_binary(filename:rootname(Main))} | Opts];
+            ({OptKey, OptValue}, Opts) when is_list(OptValue)
+                                    andalso (OptKey =:= assets
+                                      orelse OptKey =:= canonical
+                                      orelse OptKey =:= cover
+                                      orelse OptKey =:= extra_section
+                                      orelse OptKey =:= javascript_config_path
+                                      orelse OptKey =:= language
+                                      orelse OptKey =:= logo
+                                      orelse OptKey =:= output
+                                      orelse OptKey =:= source_beam
+                                      orelse OptKey =:= source_ref
+                                      orelse OptKey =:= source_url_pattern)
+                                       ->
+                [{OptKey, to_binary(OptValue)} | Opts];
+            (OtherOpt, Opts) -> % unhandled: leaving as is
+                % api_reference
+                % before_closing_body_tag
+                % before_closing_head_tag
+                % ignore_apps
+                % nest_modules_by_prefix
+                % markdown_processor
+                % skip_undefined_reference_warnings_on
+                % groups_for_modules
+                % groups_for_functions
+                [OtherOpt | Opts]
         end,
         [],
         ExDocOpts
     ).
 
-to_ex_doc_format_extras(Extras) ->
+to_ex_doc_format_filter_module(FilterModule) when is_list(FilterModule) ->
+    to_binary(FilterModule);
+to_ex_doc_format_filter_module(FilterModule) -> % unhandled: leaving as is
+    FilterModule.
+
+to_ex_doc_format_groups_for_extras(GroupsForExtras0) ->
+    maps:fold(
+        fun (Key, Value, GroupsForExtras) ->
+            GroupsForExtras#{ to_binary(Key) => to_binary(Value) }
+        end, 
+        #{},
+        GroupsForExtras0
+    ).
+
+to_ex_doc_format_extras(Extras0) ->
+    lists:foldl(
+        fun ({Extra, ExtraOpts}, Extras) ->
+                [{to_atom(Extra), to_ex_doc_format_extras_opts(ExtraOpts)} | Extras];
+            (Extra, Extras) when is_list(Extra) ->
+                [to_binary(Extra) | Extras];
+            (OtherExtra, Extras) -> % unknown: leaving as is
+                [OtherExtra | Extras]
+        end,
+        [],
+        Extras0
+    ).
+
+to_ex_doc_format_extras_opts(Extras) ->
     maps:map(
-        fun (Key, Value) when Key =:= filename
-                       orelse Key =:= title ->
-                to_binary(Value);
+        fun (filename, Filename) ->
+                to_binary(Filename);
+            (title, Title) ->
+                to_binary(Title);
             (_Key, Value) -> % unknown: leaving as is
                 Value
         end,

--- a/test/rebar3_ex_doc_SUITE.erl
+++ b/test/rebar3_ex_doc_SUITE.erl
@@ -33,7 +33,7 @@ generate_docs(Config) ->
         name => "default_docs",
         config =>
             {ex_doc, [
-                {source_url_pattern, <<"https://github.com/eh/eh">>},
+                {source_url, <<"https://github.com/eh/eh">>},
                 {extras, [<<"README.md">>, <<"LICENSE">>]},
                 {main, <<"readme">>}
             ]}
@@ -83,7 +83,7 @@ generate_docs_with_alternate_ex_doc(Config) ->
         args => "-e " ++ Alt,
         config =>
             {ex_doc, [
-                {source_url_pattern, <<"https://github.com/eh/eh">>},
+                {source_url, <<"https://github.com/eh/eh">>},
                 {extras, [<<"README.md">>, <<"LICENSE">>]},
                 {main, <<"readme">>}
             ]}
@@ -102,7 +102,7 @@ generate_docs_with_alternate_ex_doc(Config) ->
         args => "-e path/to",
         config =>
             {ex_doc, [
-                {source_url_pattern, <<"https://github.com/eh/eh">>},
+                {source_url, <<"https://github.com/eh/eh">>},
                 {extras, [<<"README.md">>, <<"LICENSE">>]},
                 {main, <<"readme">>}
             ]}
@@ -120,7 +120,7 @@ generate_docs_with_current_app_set(Config) ->
         name => "current_app",
         config =>
             {ex_doc, [
-                {source_url_pattern, <<"https://github.com/eh/eh">>},
+                {source_url, <<"https://github.com/eh/eh">>},
                 {extras, [<<"README.md">>, <<"LICENSE">>]},
                 {main, <<"readme">>}
             ]}
@@ -139,7 +139,7 @@ generate_docs_with_bad_config(Config) ->
         name => "default_docs1",
         config =>
             {ex_doc, [
-                {source_url_pattern, 'https://github.com/eh/eh'},
+                {source_url, 'https://github.com/eh/eh'},
                 {extras, ["README.md", "LICENSE"]},
                 {main, "readme"}
             ]}

--- a/test/rebar3_ex_doc_SUITE.erl
+++ b/test/rebar3_ex_doc_SUITE.erl
@@ -33,7 +33,7 @@ generate_docs(Config) ->
         name => "default_docs",
         config =>
             {ex_doc, [
-                {source_url, <<"https://github.com/eh/eh">>},
+                {source_url_pattern, <<"https://github.com/eh/eh">>},
                 {extras, [<<"README.md">>, <<"LICENSE">>]},
                 {main, <<"readme">>}
             ]}
@@ -83,7 +83,7 @@ generate_docs_with_alternate_ex_doc(Config) ->
         args => "-e " ++ Alt,
         config =>
             {ex_doc, [
-                {source_url, <<"https://github.com/eh/eh">>},
+                {source_url_pattern, <<"https://github.com/eh/eh">>},
                 {extras, [<<"README.md">>, <<"LICENSE">>]},
                 {main, <<"readme">>}
             ]}
@@ -102,7 +102,7 @@ generate_docs_with_alternate_ex_doc(Config) ->
         args => "-e path/to",
         config =>
             {ex_doc, [
-                {source_url, <<"https://github.com/eh/eh">>},
+                {source_url_pattern, <<"https://github.com/eh/eh">>},
                 {extras, [<<"README.md">>, <<"LICENSE">>]},
                 {main, <<"readme">>}
             ]}
@@ -120,7 +120,7 @@ generate_docs_with_current_app_set(Config) ->
         name => "current_app",
         config =>
             {ex_doc, [
-                {source_url, <<"https://github.com/eh/eh">>},
+                {source_url_pattern, <<"https://github.com/eh/eh">>},
                 {extras, [<<"README.md">>, <<"LICENSE">>]},
                 {main, <<"readme">>}
             ]}
@@ -139,7 +139,7 @@ generate_docs_with_bad_config(Config) ->
         name => "default_docs1",
         config =>
             {ex_doc, [
-                {source_url, "https://github.com/eh/eh"},
+                {source_url_pattern, 'https://github.com/eh/eh'},
                 {extras, ["README.md", "LICENSE"]},
                 {main, "readme"}
             ]}

--- a/test/rebar3_ex_doc_SUITE.erl
+++ b/test/rebar3_ex_doc_SUITE.erl
@@ -139,7 +139,7 @@ generate_docs_with_bad_config(Config) ->
         name => "default_docs1",
         config =>
             {ex_doc, [
-                {source_url, 'https://github.com/eh/eh'},
+                {source_url, {"https://github.com/eh/eh", 2}},
                 {extras, ["README.md", "LICENSE"]},
                 {main, "readme"}
             ]}

--- a/test/rebar3_ex_doc_SUITE.erl
+++ b/test/rebar3_ex_doc_SUITE.erl
@@ -7,6 +7,7 @@
 all() ->
     [
         generate_docs,
+        generate_docs_alternate_rebar3_config_format,
         generate_docs_with_current_app_set,
         generate_docs_with_bad_config,
         generate_docs_with_alternate_ex_doc,
@@ -35,6 +36,30 @@ generate_docs(Config) ->
                 {source_url, <<"https://github.com/eh/eh">>},
                 {extras, [<<"README.md">>, <<"LICENSE">>]},
                 {main, <<"readme">>}
+            ]}
+    },
+    {State, App} = make_stub(StubConfig),
+
+    ok = make_readme(App),
+    ok = make_license(App),
+    {ok, _} = rebar3_ex_doc:do(State),
+    check_docs(App).
+
+generate_docs_alternate_rebar3_config_format(Config) ->
+    StubConfig = #{
+        app_src => #{version => "0.1.0"},
+        dir => data_dir(Config),
+        name => "default_docs",
+        config =>
+            {ex_doc, [
+                {main, "README.md"},
+                {extras, [
+                    "README.md",
+                    {"LICENSE", #{
+                        filename => "LICENSE.md",
+                        title => "License"
+                    }
+                }]}
             ]}
     },
     {State, App} = make_stub(StubConfig),


### PR DESCRIPTION
We:

1. prevent mixed use of atoms, strings and binaries (prefer Erlang strings everywhere - syntax is the same as Elixir strings),
2. have `main` be readable as a filename, so a reference is easy to understand,
3. keep backward compatibility by only modifying the stuff we "see" in the _new format_.

Closes #20.

Some questions still remain, though.

`README.md` (from `rebar3_ex_doc`) refers `source_url`, for example, but I don't see that (in [mix docs](https://hexdocs.pm/ex_doc/Mix.Tasks.Docs.html)) inside `docs`, so it's confusing (is there some kind of modification already done by `mix docs` here)? (I do see `source_url_pattern`, there). **Edit**: refer to the latest commit for changes regarding this.

~We're being explicit in the keys we want to handle, so whatever isn't in the `docs` documentation we're leaving as-is, but (as you can see per the changes in `README.md` this makes for still inconsistent `ex_docs` options' region, in `rebar.config`).~ (new commit removes this "question")

I'm going to push a further commit to try and be more specific still. (looking at all of `mix docs` accepted options).

**Edit**:

When trying to go down the "try and be more specific" path, I find myself with exceptions like "lists of lists" (which means I have to pattern match on the option name), "functions as input" (I'm not sure this translates to `rebar.config`), and whatnot.