### PR TITLE
Switch foldl to foldr to preserve extra pages order

### DIFF
--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -281,7 +281,7 @@ to_ex_doc_format(ExDocOpts) ->
     ).
 
 to_ex_doc_format_extras(Extras0) ->
-    lists:foldl(
+    lists:foldr(
         fun ({Extra, ExtraOpts}, Extras) ->
                 [{to_atom(Extra), to_ex_doc_format_extras_opts(ExtraOpts)} | Extras];
             (Extra, Extras) when is_list(Extra) ->


### PR DESCRIPTION
This fixes an issue where by order of extra pages got reversed due to a `foldl/2` operation. 

Closes #27 