### PR TITLE
Prevent warnings when passing the "logo" option

### DIFF
--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -270,6 +270,8 @@ to_ex_doc_format(ExDocOpts) ->
                 [{K, to_binary(SourceURL)} | Opts];
             ({proglang, _} = V, Opts) -> % internal exception
                 [V | Opts];
+            ({logo, _} = V, Opts) ->
+                [V | Opts];
             (OtherOpt, Opts) ->
                 rebar_api:warn("unknown ex_doc option ~p", [OtherOpt]),
                 [OtherOpt | Opts]


### PR DESCRIPTION
The logo option works out-of-the-box so we can skip emitting a warning. In ExDoc, the logo configuration option is a `nil | Path.t()`[^1] and charlists are valid paths[^2], so conversion to a binary is not necessary.

[^1]: https://github.com/elixir-lang/ex_doc/blob/a43392a1c84c4bd67f8e173b34b5d10f476beb5a/lib/ex_doc/config.ex#L65
[^2]: https://github.com/elixir-lang/elixir/blob/v1.14.1/lib/elixir/lib/path.ex#L19, https://github.com/elixir-lang/elixir/blob/v1.14.1/lib/elixir/lib/io.ex#L123