### PR TITLE
Translate 'skip_undefined_reference_warnings_on' ExDoc option

### DIFF
--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -272,6 +272,9 @@ to_ex_doc_format(ExDocOpts) ->
                 [V | Opts];
             ({logo, _} = V, Opts) ->
                 [V | Opts];
+            ({skip_undefined_reference_warnings_on = K, Skips0}, Opts) ->
+                Skips = [to_binary(Skip) || Skip <- Skips0],
+                [{K, Skips} | Opts];
             (OtherOpt, Opts) ->
                 rebar_api:warn("unknown ex_doc option ~p", [OtherOpt]),
                 [OtherOpt | Opts]


### PR DESCRIPTION
ExDoc uses this option to silence autolink warnings (warnings like "X references "init/1" but it is hidden") in [`ExDoc.Autolink.maybe_warn`](https://github.com/elixir-lang/ex_doc/blob/41475624f292897237e6aba3c8f8ecadc6836330/lib/ex_doc/autolink.ex#L123-L131). The skips in this list are checked against binaries so to translate between rebar3_ex_doc and ExDoc, we only need to ensure that each of the skipped elements is a binary.