### PR TITLE
add support for the "output" configuration option

### DIFF
--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -275,6 +275,8 @@ to_ex_doc_format(ExDocOpts) ->
             ({skip_undefined_reference_warnings_on = K, Skips0}, Opts) ->
                 Skips = [to_binary(Skip) || Skip <- Skips0],
                 [{K, Skips} | Opts];
+            ({output = K, OutputDir}, Opts) ->
+                [{K, to_binary(OutputDir)} | Opts];
             (OtherOpt, Opts) ->
                 rebar_api:warn("unknown ex_doc option ~p", [OtherOpt]),
                 [OtherOpt | Opts]


### PR DESCRIPTION
Both edoc and ex_doc use the same default output directory (doc/). We can now override the ex_doc default via rebar.config.