### PR TITLE
Allow external config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ For further customization, see the configuration for `rebar3_ex_doc`:
 
 Please see the `ex_doc` [configuration documentation](https://hexdocs.pm/ex_doc/Mix.Tasks.Docs.html#module-configuration) for a complete overview of available configuration directives.
 
+You may also use an external config file by specifying a path instead of a proplist. See `ex_doc --help` for more info.
+
+```erlang
+%% In Elixir format
+{ex_doc, "docs.exs"}.
+
+%% Or in Erlang term, like rebar.config
+{ex_doc, "docs.config"}.
+```
+
 ### Umbrella support
 
 Umbrellas are supported but they must be configured on an app by app basis. This is to avoid publishing documentation to Hex.pm with wrong source urls, logos, etc.

--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -247,11 +247,16 @@ win32_ex_doc_script(Path) ->
 
 -spec ex_doc_config_file(rebar_app_info:t(), file:filename()) -> file:filename().
 ex_doc_config_file(App, EdocOutDir) ->
-    ExDocOpts0 = ex_doc_opts_defaults(rebar_app_info:get(App, ex_doc, [])),
-    ExDocOpts = to_ex_doc_format(ExDocOpts0),
-    ExDocConfigFile = filename:join([EdocOutDir, "docs.config"]),
-    ok = write_config(ExDocConfigFile, ExDocOpts),
-    ExDocConfigFile.
+    case rebar_app_info:get(App, ex_doc, []) of
+        ExDocOpts0 when ExDocOpts0 =:= [] orelse is_tuple(hd(ExDocOpts0)) orelse is_atom(hd(ExDocOpts0)) ->
+            ExDocOpts1 = ex_doc_opts_defaults(ExDocOpts0),
+            ExDocOpts2 = to_ex_doc_format(ExDocOpts1),
+            ExDocConfigFile = filename:join([EdocOutDir, "docs.config"]),
+            ok = write_config(ExDocConfigFile, ExDocOpts2),
+            ExDocConfigFile;
+        ExDocConfigFile ->
+            ExDocConfigFile
+    end.
 
 to_ex_doc_format(ExDocOpts) ->
     lists:foldl(


### PR DESCRIPTION
This adds support for an external config file, for example if you want to share the config with Elixir or as an escape hatch to be able to use a `fun` for `:filter_modules`.