### PR TITLE
Allow generation of docs outside the context of a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ To integrate with `rebar3_hex` merely specify `rebar3_ex_doc` as the doc provide
 ]}.
 ```
 
+#### packages
+
+rebar3_ex_doc optimizes for applications intended to be published to [hex.pm](https://hex.pm) such that
+the application name is passed to ex_doc by default as the value to the package option.
+
+If you wish to generate documentation outside the context of a package you may specify `{package, false}` in the options :
+
+```erlang
+{ex_doc, [
+     {package, false},
+     {extras, ["README.md", "LICENSE"]},
+     {main, "README.md"},
+     {source_url, "https://github.com/namespace/your_app"}
+]}.
+```
+
 ### Supported options
 
 Not all `ex_doc` options are supported. This means we'll warn on unknown options, but still pass them to `ex_doc`. We try to make sure the supported options are converted to the format known by `ex_doc`.

--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -195,8 +195,6 @@ make_command_string(State, App, EdocOutDir, Opts) ->
         AppName,
         Vsn,
         Ebin,
-        "--package",
-        rebar_utils:to_list(PkgName),
         "--source-ref",
         SourceRefVer,
         "--config",
@@ -204,7 +202,7 @@ make_command_string(State, App, EdocOutDir, Opts) ->
         "--output",
         output_dir(App, Opts),
         "--quiet"
-    ],
+    ] ++ maybe_package_arg(PkgName, rebar_app_info:get(App, ex_doc, [])),
     DepPaths = rebar_state:code_paths(State, all_deps),
     PathArgs = lists:foldl(
         fun(Path, Args) -> ["--paths", Path | Args] end,
@@ -218,6 +216,18 @@ make_command_string(State, App, EdocOutDir, Opts) ->
         Optionals
     ),
     string:join(CommandArgs, " ").
+
+maybe_package_arg(PkgName, Opts) when Opts =:= []
+                                      orelse is_tuple(hd(Opts))
+                                      orelse is_atom(hd(Opts)) ->
+    case proplists:get_value(package, Opts, true) of
+        true ->
+            ["--package", rebar_utils:to_list(PkgName)];
+        false ->
+            []
+    end;
+maybe_package_arg(_, _) ->
+    [].
 
 ex_doc_escript(Opts) ->
     ExDoc = ex_doc_script_path(Opts),


### PR DESCRIPTION
This PR adds the ability to specify whether the docs you're generating for your project is or will be a package on hex. There's still some hex links that remain, but that has to be fixed up in ex_doc itself. 

Resolves #16 