### PR TITLE
Remove warnings from examples

### DIFF
--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -296,6 +296,10 @@ to_ex_doc_format(ExDocOpts) ->
                 [V | Opts];
             ({logo, _} = V, Opts) ->
                 [V | Opts];
+            ({before_closing_body_tag, _} = V, Opts) ->
+                [V | Opts];
+            ({before_closing_head_tag, _} = V, Opts) ->
+                [V | Opts];
             ({skip_undefined_reference_warnings_on = K, Skips0}, Opts) ->
                 Skips = [to_binary(Skip) || Skip <- Skips0],
                 [{K, Skips} | Opts];


### PR DESCRIPTION
These should be the same type as `ex_doc`'s, right? i.e. "no conversion required" (?)