### PR TITLE
Minor doc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ graph TD;
 #### v prefix for source ref versions
 
 By default rebar3_ex_doc adopts the convention of prefixing versions with `v`.
-If your project doesn't followthis convention you may opt out of it with `{prefix_ref_vsn_with_v, false}`
+If your project doesn't follow this convention you may opt out of it with `{prefix_ref_vsn_with_v, false}`
 
 ```erlang
 {ex_doc, [
@@ -194,36 +194,36 @@ If you'd like to hack on this plugin, follow the steps below:
 2. Make a new rebar project or go into an existing project:
 
     ```bash
-    $ rebar3 new myapp
-    $ cd myapp
+    rebar3 new myapp
+    cd myapp
     ```
 
 3. Make a `_checkouts` directory:
 
     ```bash
-    $ mkdir _checkouts
+    mkdir _checkouts
     ```
 
 4. Go to `_checkouts` and clone this repository to create a
    [checkout dependency](http://rebar3.org/docs/configuration/dependencies/#checkout-dependencies):
 
     ```bash
-    $ cd _checkouts
-    $ git clone https://github.com/starbelly/rebar3_ex_doc
+    cd _checkouts
+    git clone https://github.com/starbelly/rebar3_ex_doc
     ```
 
 5. Get all dependencies and build the `ex_doc` console app:
 
     ```bash
-    $ cd rebar3_ex_doc
-    $ mix deps.get
-    $ mix escript.build
+    cd rebar3_ex_doc
+    mix deps.get
+    mix escript.build
     ```
 
 6. Go back to the root of your project:
 
     ```bash
-    $ cd ../..
+    cd ../..
     ```
 
 7. Add `rebar3_ex_doc` as plugin to your `rebar.config`:
@@ -235,7 +235,7 @@ If you'd like to hack on this plugin, follow the steps below:
 8. Generate documentation as an initial test:
 
     ```bash
-    $ rebar3 ex_doc
+    rebar3 ex_doc
     ```
 
 ## Copyright and License

--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,8 @@
     {source_url, <<"https://github.com/starbelly/rebar3_ex_doc">>},
     {assets, <<"assets">>},
     {api_reference, false},
-    {with_mermaid, true}
+    {with_mermaid, true},
+    {skip_undefined_reference_warnings_on, ["README.md"]}
 ]}.
 
 {profiles, [

--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -504,7 +504,7 @@ cmd_vsn_invoke(Cmd, Dir) ->
 help(app) ->
     "Specify which app to generate docs for within an umbrella project.";
 help(ex_doc) ->
-    "Specifiy a path to an alternate version of ex_doc on your system (e.g., /path/to/ex_doc).";
+    "Specify a path to an alternate version of ex_doc on your system (e.g., /path/to/ex_doc).";
 help(canonical) ->
     "Indicate the preferred URL with rel=\"canonical\" link element,"
     "defaults to no canonical path.";


### PR DESCRIPTION
List of changes:
- fix typos
- disable warnings on readme on doc references
- remove `$` from shell code block when click and copy