### PR TITLE
Use include_paths directive in app.src

### DIFF
--- a/src/rebar3_ex_doc.app.src
+++ b/src/rebar3_ex_doc.app.src
@@ -9,6 +9,6 @@
   {env,[]},
   {modules, []},
   {licenses, ["Apache-2.0"]},
-  {include_files, ["priv/ex_doc"]},
+  {include_paths, ["priv/ex_doc"]},
   {links, [{"Github", "https://github.com/starbelly/rebar3_ex_doc"}]}
  ]}.


### PR DESCRIPTION
`include_files` was deprecated in rebar3_hex (partially by me 😝), we should be using `include_paths` instead. This commit addresses this problem. 