### PR TITLE
Fix link to example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ If your project doesn't follow this convention you may opt out of it with `{pref
 
 ### Examples
 
-Check out our [examples](examples) directory in this repository for working project examples.
+Check out our [examples](https://github.com/starbelly/rebar3_ex_doc/tree/main/examples) directory in this repository for working project examples.
 
 ### Extras
 

--- a/src/rebar3_ex_doc.app.src
+++ b/src/rebar3_ex_doc.app.src
@@ -1,6 +1,6 @@
 {application, rebar3_ex_doc,
  [{description, "rebar3 plugin for generating docs with ex_doc"},
-  {vsn, "0.2.21"},
+  {vsn, "0.2.22"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
We publish the README to hex.pm but rely on implicit linking on github which will result in 404 for users trying to hit examples from hexdocs.

Closes #76 

I originally said we'd fix this once the repo is transferred to jelly-beam, but that's a bit silly, a bug exists, it should be fixed. We can just update it as part of the transfer. 