### PR TITLE
Allow for a control issue to let us know when CI's failing

### DIFF
--- a/.github/workflows/up_ex_doc_version.yml
+++ b/.github/workflows/up_ex_doc_version.yml
@@ -37,7 +37,7 @@ jobs:
       - run: |
             CURR=$(curl -s https://hex.pm/api/packages/ex_doc | jq -r '.latest_stable_version')
             TITLE="[automation] Update \`ex_doc\` to ${CURR}"
-            PR=$(curl -s https://api.github.com/repos/"${GITHUB_REPOSITORY}"/pulls?state=all%26per_page=100 | jq ".[] | select(.title==\"${TITLE}\")")
+            PR=$(curl -s https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?state=all%26per_page=100 | jq ".[] | select(.title==\"${TITLE}\")")
 
             echo "Searching for pull request with title ${TITLE}..."
             
@@ -65,7 +65,7 @@ jobs:
 
               set +e
               rebar3 do dialyzer, ct
-                UP_EX_DOC_VERSION_CONTROL_ISSUE=85
+              UP_EX_DOC_VERSION_CONTROL_ISSUE=85
               if [ $? -ne 0 ]; then
                 gh issue reopen "${UP_EX_DOC_VERSION_CONTROL_ISSUE}" || true
                 gh issue edit "${UP_EX_DOC_VERSION_CONTROL_ISSUE}" -t "[automation] Workflow \`up_ex_doc_version\` failed" -b "Something's wrong with workflow \`up_ex_doc_version\`. Check [this](/${GITHUB_REPOSITORY}/actions/workflows/up_ex_doc_version.yml)."

--- a/.github/workflows/up_ex_doc_version.yml
+++ b/.github/workflows/up_ex_doc_version.yml
@@ -11,26 +11,33 @@ jobs:
     name: Update ex_doc version
     runs-on: ubuntu-latest
     strategy:
+    strategy:
+      max-parallel: 1
       matrix:
-        pair:
+        triplet:
           - otp: '24'
             elixir: '1.13'
+            rebar3: '3.22'
           - otp: '25'
             elixir: '1.14'
+            rebar3: '3.22'
           - otp: '26'
             elixir: '1.15'
+            rebar3: '3.22'
           - otp: '27.0-rc1'
             elixir: '1.16'
+            rebar3: '3.22'
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{matrix.pair.otp}}
-          elixir-version: ${{matrix.pair.elixir}}
+          otp-version: ${{matrix.triplet.otp}}
+          elixir-version: ${{matrix.triplet.elixir}}
+          rebar3-version: ${{matrix.triplet.rebar3}}
       - run: |
             CURR=$(curl -s https://hex.pm/api/packages/ex_doc | jq -r '.latest_stable_version')
             TITLE="[automation] Update \`ex_doc\` to ${CURR}"
-            PR=$(curl -s https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?state=all%26per_page=100 | jq ".[] | select(.title==\"${TITLE}\")")
+            PR=$(curl -s https://api.github.com/repos/"${GITHUB_REPOSITORY}"/pulls?state=all%26per_page=100 | jq ".[] | select(.title==\"${TITLE}\")")
 
             echo "Searching for pull request with title ${TITLE}..."
             
@@ -56,17 +63,28 @@ jobs:
               mix deps.unlock ex_doc
               mix deps.get
 
-              if ! git diff --exit-code 1> /dev/null ; then
-                  echo "There's stuff to push. Creating a pull request..."
-                  git add .
-                  git commit -m "${TITLE}"
-                  git push origin "$BRANCH"
-
-                  gh pr create --fill \
-                      --title "${TITLE}" \
-                      --body "This is an automated action to update \`ex_doc\` to version ${CURR}"
+              set +e
+              rebar3 do dialyzer, ct
+                UP_EX_DOC_VERSION_CONTROL_ISSUE=85
+              if [ $? -ne 0 ]; then
+                gh issue reopen "${UP_EX_DOC_VERSION_CONTROL_ISSUE}" || true
+                gh issue edit "${UP_EX_DOC_VERSION_CONTROL_ISSUE}" -t "[automation] Workflow \`up_ex_doc_version\` failed" -b "Something's wrong with workflow \`up_ex_doc_version\`. Check [this](/${GITHUB_REPOSITORY}/actions/workflows/up_ex_doc_version.yml)."
+                exit 1
               else
-                  echo "Nothing to push. Is \`ex_doc\` already at version ${CURR}?"
+                set -e
+                gh issue close "${UP_EX_DOC_VERSION_CONTROL_ISSUE}" || true
+                if ! git diff --exit-code 1> /dev/null ; then
+                    echo "There's stuff to push. Creating a pull request..."
+                    git add .
+                    git commit -m "${TITLE}"
+                    git push origin "$BRANCH"
+
+                    gh pr create --fill \
+                        --title "${TITLE}" \
+                        --body "This is an automated action to update \`ex_doc\` to version ${CURR}"
+                else
+                    echo "Nothing to push. Is \`ex_doc\` already at version ${CURR}?"
+                fi
               fi
             else
               echo "  ... found! Bailing out..."


### PR DESCRIPTION
I'm proposing a workflow failure verification mechanism, via [an issue in this repo.](https://github.com/starbelly/rebar3_ex_doc/issues/85), to allow us to understand when the scheduled `up_ex_doc_version` might be failing.

**Note**: inspiration to this came from https://docs.renovatebot.com/, and the way they maintain dependency versioning via a control issue.

## How does this work?

If `rebar3 do dialyzer, ct` fails, we reopen (whether it's closed or not) the control issue (#85) and update its title and body, with a link to the failing workflow (after which visual inspect follows). We keep the concurrency of running that workflow to `1` to prevent a further success from closing the issue if it's already open. Hopefully, we'll not have to manage the issue by hand (since the schedule CI workflow should do that for us).

## What's the advantage?

This allows us to detect an otherwise silent failure and workaround the fact that, at least for the most important validations (`rebar3 ct` and `rebar3 dialyzer`, as expected by workflow `ci.yml`) we're not failing.

## How can I test this?

I've tested this in my fork of `rebar3_ex_doc` but one easy way to test it would be to:

1. force-push something to the main branch which would make e.g. `dialyzer` fail,
2. dispatch the `up_ex_doc_version` workflow,
3. check that issue #85 is reopened
4. fix what we broke, in 2., and push to the main branch again
5. re-dispatch the `up_ex_doc_version` workflow
3. check that issue #85 is closed