### PR TITLE
Move support window to OTP 25-27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
             rebar3: '3.22.1'
           - otp: '26'
             rebar3: '3.22.1'
+          - otp: '27'
+            rebar3: '3.23'
           - otp: 'master'
             rebar3: 'nightly'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
     strategy:
       matrix:
         triplet:
-          - otp: '24'
-            elixir: '1.13'
-            rebar3: '3.22.1'
           - otp: '25'
             elixir: '1.14'
             rebar3: '3.22.1'
           - otp: '26'
             elixir: '1.15'
             rebar3: '3.22.1'
+          - otp: '27'
+            elixir: '1.17'
+            rebar3: '3.23'
           - otp: 'master'
             elixir: 'main'
             rebar3: 'nightly'
@@ -45,14 +45,14 @@ jobs:
       max-parallel: 1
       matrix:
         triplet:
-          - otp: '24'
-            elixir: '1.13'
-            cache-id: oldest
           - otp: '25'
             elixir: '1.14'
-            cache-id: plus_one
+            cache-id: oldest
           - otp: '26'
             elixir: '1.15'
+            cache-id: plus_one
+          - otp: '27'
+            elixir: '1.17'
             cache-id: plus_two
           - otp: 'master'
             elixir: 'main'
@@ -82,8 +82,6 @@ jobs:
     strategy:
       matrix:
         pair:
-          - otp: '24'
-            rebar3: '3.22.1'
           - otp: '25'
             rebar3: '3.22.1'
           - otp: '26'

--- a/.github/workflows/up_ex_doc_version.yml
+++ b/.github/workflows/up_ex_doc_version.yml
@@ -14,15 +14,15 @@ jobs:
       max-parallel: 1
       matrix:
         triplet:
-          - otp: '24'
-            elixir: '1.13'
-            rebar3: '3.22'
           - otp: '25'
             elixir: '1.14'
             rebar3: '3.22'
           - otp: '26'
             elixir: '1.15'
             rebar3: '3.22'
+          - otp: '27'
+            elixir: '1.17'
+            rebar3: '3.23'
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/up_ex_doc_version.yml
+++ b/.github/workflows/up_ex_doc_version.yml
@@ -23,9 +23,6 @@ jobs:
           - otp: '26'
             elixir: '1.15'
             rebar3: '3.22'
-          - otp: '27.0-rc1'
-            elixir: '1.16'
-            rebar3: '3.22'
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ This plugin can be used to generate documentation on its own and also integrates
 ## Installation
 
 **NOTE**: This plugin and more importantly `ex_doc` depend on `edocs` capability to generate beam chunks per [EEP-48](https://www.erlang.org/doc/apps/erl_docgen/doc_storage.html).
-Thus, the minimum OTP version supported by this plugin is Erlang/OTP 24.
+
+## Maintenance window
+
+The minimum OTP version supported by this plugin is Erlang/OTP 25.
 
 ### As a global plugin
 

--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -53,7 +53,7 @@ init(State) ->
     {ok, rebar_state:t()} | {error, string()} | {error, {module(), any()}}.
 do(State) ->
     case otp_release() of
-        Min when Min >= 24 ->
+        Min when Min >= 25 ->
             Apps = get_apps(State),
             run(State, Apps);
         Ver ->
@@ -81,7 +81,7 @@ format_error({write_config, Err}) ->
     rebar_api:debug("Unknown error error occurred generating docs config: ~p", [Err]),
     "An unknown error occurred generating docs config. Run with DIAGNOSTICS=1 for more details.";
 format_error({unsupported_otp, Ver}) ->
-    Str = "You are using Erlang/OTP '~ts', but this plugin requires at least Erlang/OTP 24.",
+    Str = "You are using Erlang/OTP '~ts', but this plugin requires at least Erlang/OTP 25.",
     io_lib:format(Str, [integer_to_list(Ver)]);
 format_error({mermaid_vsn_not_string, Vsn}) ->
     Str = "ex_doc option 'with_mermaid' should be 'true', 'false', or string(). Got: ~p",


### PR DESCRIPTION
We thus align with other tools doing the same in the ecosystem, e.g. like `rebar3`. Lemme know if you feel this is a drastic change. (I think we discussed it, which is why we find `oldest`, `plus_one`, `plus_two`, `plus_three` in the workflow files, but I can't quite say when - or if we did 😄)