### PR TITLE
Fix #123: continue with ex_doc when EDoc fails for native-docs projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Generating docs no longer aborts for projects using native `-moduledoc`/`-doc`
+  attributes (OTP 27+, EEP-59) when a Markdown backtick appears in an Erlang
+  `%%` comment attached to a declaration. EDoc's legacy wiki parser throws on
+  such comments ([#123](https://github.com/jelly-beam/rebar3_ex_doc/issues/123)).
+  Because `ex_doc` reads documentation directly from the EEP-48 `Docs` chunk in
+  the compiled BEAM, the EDoc step is redundant for these projects: when EDoc
+  fails and populated native docs are present in the beams, the real EDoc error
+  is now logged as a warning and doc generation continues. Note that this
+  graceful degradation applies to *any* EDoc failure for a native-docs app, not
+  only the backtick crash. Projects documented with legacy EDoc `@doc` comments
+  (no native docs in the beams) are unaffected and still fail fast on EDoc
+  errors.
+
 ## [v0.3.0]
 
 - Update ex_doc to 0.40.3

--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ If you wish to generate documentation outside the context of a package you may s
 Not all `ex_doc` options are supported. This means we'll warn on unknown options, but still pass them to `ex_doc`. We try to make sure the supported options are converted to the format known by `ex_doc`.
 In case you get a warning for something that is working or would like further conversion support, open a [GitHub issue](https://github.com/starbelly/rebar3_ex_doc/issues).
 
+### Native documentation and EDoc
+
+For projects documented with native `-moduledoc`/`-doc` attributes (OTP 27+,
+EEP-59), `ex_doc` reads documentation directly from the compiled BEAM's EEP-48
+`Docs` chunk, so the intermediate EDoc step is not required. The `Docs` chunk
+is emitted by the compiler by default (it is only suppressed by the explicit
+`+no_docs` / `-compile(no_docs)` option). If EDoc fails to run — for example, a
+Markdown backtick in an Erlang `%%` comment trips EDoc's legacy wiki parser
+(see [#123](https://github.com/jelly-beam/rebar3_ex_doc/issues/123)) — and the
+compiled beams contain native docs, the plugin logs the underlying EDoc error
+and continues, generating docs from the BEAM. As usual, `ex_doc` renders
+type/spec information from `debug_info` (the rebar3 default), so keep it enabled
+for complete output. Projects that rely on legacy `@doc` comments still depend
+on EDoc and will report the error and stop, as before.
+
 ### Additional options
 
 #### Support for Mermaid

--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -149,7 +149,8 @@ compile(State) ->
             ?RAISE({compile, Err})
     end.
 
--spec gen_chunks(rebar_state:t(), file:filename()) -> {rebar_state:t(), rebar_app_info:t(), file:filename()}.
+-spec gen_chunks(rebar_state:t(), rebar_app_info:t()) ->
+    {rebar_state:t(), rebar_app_info:t(), file:filename()}.
 gen_chunks(State, App) ->
     OutDir = filename:join(rebar_app_info:out_dir(App), "doc"),
     ErlOpts = rebar_state:get(State, erl_opts, []),
@@ -172,8 +173,89 @@ gen_chunks(State, App) ->
         {ok, State3} ->
             {State3, App1, OutDir};
         {error, Err} ->
-            ?RAISE({gen_chunks, Err})
+            %% Issue #123: EDoc's legacy wiki parser throws on a Markdown
+            %% backtick in a `%%' comment attached to a declaration. For
+            %% projects using native EEP-59 docs (-moduledoc/-doc) the EDoc
+            %% step is vestigial: ex_doc reads the EEP-48 Docs chunk directly
+            %% from the compiled BEAM. So if the app already ships native docs,
+            %% surface the real EDoc error and continue to ex_doc instead of
+            %% aborting. Legacy @doc / undocumented apps depend on EDoc and
+            %% still abort exactly as before.
+            case has_native_docs(App) of
+                true ->
+                    rebar_api:warn(
+                        "edoc failed for '~ts' but native (-moduledoc/-doc) "
+                        "documentation was found in the compiled beams; "
+                        "continuing with ex_doc. edoc error: ~p",
+                        [rebar_app_info:name(App), Err]
+                    ),
+                    ok = filelib:ensure_path(OutDir),
+                    %% NB: we return the pristine State/App here, not the
+                    %% edoc-mutated State3/App1 of the success arm. ex_doc/3
+                    %% reads only command_parsed_args/vcs_vsn/code_paths from
+                    %% State and name/dir/ebin_dir/ex_doc opts from App, none of
+                    %% which the (skipped) edoc step mutates, so returning the
+                    %% originals is equivalent and avoids leaking edoc_opts /
+                    %% project_apps mutations into the ex_doc step.
+                    {State, App, OutDir};
+                false ->
+                    ?RAISE({gen_chunks, Err})
+            end
     end.
+
+%% @doc Returns `true' iff at least one compiled beam in the app's ebin dir
+%% carries a populated EEP-48 `Docs' chunk (native -moduledoc/-doc, EEP-59),
+%% i.e. a docs_v1 term whose module doc and/or at least one entry doc is a
+%% non-empty language map. Modules compiled without -moduledoc/-doc (and
+%% without an edoc-to-chunks pass over the same ebin) carry no Docs chunk;
+%% modules that opted out (-moduledoc false / -doc hidden) carry atom-valued
+%% docs; both correctly yield `false'. Used on edoc failure to decide whether
+%% the edoc step is vestigial and ex_doc can render from the beam alone (issue
+%% #123). Defensively returns `false' on any beam_lib/binary_to_term error so a
+%% malformed beam never masks the original edoc failure for legacy projects.
+%% Note: this is a heuristic on the presence of native docs in the beams; if
+%% maintainers prefer determinism it could be replaced by an explicit opt-in
+%% flag (see the #123 discussion).
+-spec has_native_docs(rebar_app_info:t()) -> boolean().
+has_native_docs(App) ->
+    Beams = filelib:wildcard(filename:join(rebar_app_info:ebin_dir(App), "*.beam")),
+    lists:any(fun beam_has_native_docs/1, Beams).
+
+-spec beam_has_native_docs(file:filename()) -> boolean().
+beam_has_native_docs(Beam) ->
+    try beam_lib:chunks(Beam, ["Docs"], [allow_missing_chunks]) of
+        {ok, {_Module, [{"Docs", Bin}]}} when is_binary(Bin) ->
+            docs_chunk_populated(Bin);
+        _ ->
+            false
+    catch
+        _:_ ->
+            false
+    end.
+
+-spec docs_chunk_populated(binary()) -> boolean().
+docs_chunk_populated(Bin) ->
+    try binary_to_term(Bin) of
+        {docs_v1, _Anno, _Lang, _Format, ModuleDoc, _Meta, Docs} ->
+            is_populated_doc(ModuleDoc) orelse lists:any(fun is_populated_entry/1, Docs);
+        _ ->
+            false
+    catch
+        _:_ ->
+            false
+    end.
+
+-spec is_populated_entry(term()) -> boolean().
+is_populated_entry({_KindNameArity, _Anno, _Sig, Doc, _Meta}) ->
+    is_populated_doc(Doc);
+is_populated_entry(_) ->
+    false.
+
+-spec is_populated_doc(term()) -> boolean().
+is_populated_doc(Doc) when is_map(Doc) ->
+    map_size(Doc) > 0;
+is_populated_doc(_) ->
+    false.
 
 -spec ex_doc(rebar_state:t(), rebar_app_info:t(), file:filename()) -> {ok, rebar_state:t()}.
 ex_doc(State, App, EdocOutDir) ->

--- a/test/rebar3_ex_doc_SUITE.erl
+++ b/test/rebar3_ex_doc_SUITE.erl
@@ -28,7 +28,12 @@ all_post_27(OTPRelease) when OTPRelease >= 27 ->
         generate_docs_with_bad_config_post_27,
         generate_docs_with_alternate_ex_doc_post_27,
         generate_docs_with_output_set_in_config_post_27,
-        generate_docs_overriding_output_set_in_config_post_27
+        generate_docs_overriding_output_set_in_config_post_27,
+        %% The following #123 regression tests are intentionally post-27-only
+        %% (no _post_27 sibling): they exercise native -moduledoc/-doc, which
+        %% only exists on OTP >= 27.
+        generate_docs_native_docs_survive_edoc_backtick_crash,
+        generate_docs_legacy_docs_still_abort_on_edoc_backtick_crash
     ];
 all_post_27(_OTPRelease) ->
     [].
@@ -279,6 +284,71 @@ generate_docs_overriding_output_set_in_config(Config) ->
     {ok, _} = rebar3_ex_doc:do(State),
     check_docs(App, State, StubConfig).
 
+generate_docs_native_docs_survive_edoc_backtick_crash(Config) ->
+    %% Regression for #123: a native -doc project with a Markdown backtick in a
+    %% %% comment attached to a declaration makes edoc:get_doc/2 throw. Because
+    %% the app ships populated native Docs chunks in its beams, doc generation
+    %% must NOT abort: the plugin logs the edoc error and lets ex_doc render
+    %% straight from the beam. No special config required.
+    %%
+    %% Coverage note: this asserts the GRACEFUL path ({ok,_} + rendered docs).
+    %% Its sibling generate_docs_legacy_docs_still_abort_on_edoc_backtick_crash
+    %% asserts the SAME edoc crash still aborts a legacy project, which pins the
+    %% precondition that the type-attached backtick really throws under edoc. If
+    %% a future OTP stops throwing, that sibling fails loudly, so this test
+    %% cannot silently pass via the {ok,State3} edoc-success arm unnoticed.
+    StubConfig = #{
+        app_src => #{version => "0.1.0"},
+        dir => data_dir(Config),
+        name => "native_backtick_comment",
+        src_variant => backtick_comment,
+        config =>
+            {ex_doc, [
+                {source_url, <<"https://github.com/eh/eh">>},
+                {extras, [<<"README.md">>, <<"LICENSE">>]},
+                {main, <<"readme">>}
+            ]}
+    },
+    %% post_27 forced true: native -moduledoc/-doc only exists on OTP >= 27.
+    {State, App} = make_stub(true, StubConfig),
+    ok = make_readme(App),
+    ok = make_license(App),
+    {ok, _} = rebar3_ex_doc:do(State),
+    check_docs(App, State, StubConfig).
+
+generate_docs_legacy_docs_still_abort_on_edoc_backtick_crash(Config) ->
+    %% Backward-compat guard for #123: a LEGACY (@doc, no -moduledoc/-doc)
+    %% project that hits the same edoc backtick crash must STILL fail fast.
+    %% has_native_docs/1 returns false (the beam carries no populated Docs
+    %% chunk), so gen_chunks/2 re-raises ?RAISE({gen_chunks, _}) exactly as
+    %% before this fix. This locks down the has_native_docs=false -> abort
+    %% branch so a future regression that loosened native-docs detection (e.g.
+    %% treating missing_chunk or opt-out 'hidden' docs as populated) would be
+    %% caught here instead of silently downgrading a real edoc failure to a
+    %% warning for legacy projects.
+    StubConfig = #{
+        app_src => #{version => "0.1.0"},
+        dir => data_dir(Config),
+        name => "legacy_backtick_comment",
+        src_variant => legacy_backtick_comment,
+        config =>
+            {ex_doc, [
+                {source_url, <<"https://github.com/eh/eh">>},
+                {extras, [<<"README.md">>, <<"LICENSE">>]},
+                {main, <<"readme">>}
+            ]}
+    },
+    {State, App} = make_stub(true, StubConfig),
+    ok = make_readme(App),
+    ok = make_license(App),
+    %% ?RAISE wraps the reason as {error, {?MODULE, Reason}} (the ?PRV_ERROR
+    %% shape rebar3 expects from a provider), so erlang:error/1 carries that
+    %% full term. Matching it confirms the legacy abort path (?RAISE) was hit.
+    ?assertError(
+        {error, {rebar3_ex_doc, {gen_chunks, _}}},
+        rebar3_ex_doc:do(State)
+    ).
+
 format_errors(_) ->
     Err = "The app 'foo' specified was not found.",
     ?assertEqual(Err, rebar3_ex_doc:format_error({app_not_found, foo})),
@@ -496,10 +566,11 @@ init_state(Dir, Config) ->
     LibDirs = rebar_dir:lib_dirs(State),
     rebar_app_discover:do(State, LibDirs).
 
-write_src_file(Post27, Dir, #{name := Name}) ->
+write_src_file(Post27, Dir, #{name := Name} = StubConfig) ->
     Erl = filename:join([Dir, "src", Name ++ ".erl"]),
     ok = filelib:ensure_dir(Erl),
-    ok = ec_file:write(Erl, erl_src_file(Post27, Name)).
+    Variant = maps:get(src_variant, StubConfig, Post27),
+    ok = ec_file:write(Erl, erl_src_file(Variant, Name)).
 
 write_app_src_file(Dir, #{name := Name, app_src := #{version := Vsn}}) ->
     Filename = filename:join([Dir, "src", Name ++ ".app.src"]),
@@ -523,6 +594,55 @@ get_app_metadata(Name, Vsn) ->
         {links, []}
     ]}.
 
+erl_src_file(backtick_comment = _Variant, Name) ->
+    %% Native -moduledoc/-doc module with a Markdown backtick (ASCII 0x60) in a
+    %% %% comment attached to a -type declaration. This is the exact #123 repro
+    %% ("Crashes if type comment has backticks"): with {preprocess,true}
+    %% edoc:get_doc/2 throws ("`-quote ended unexpectedly at line N"). The BEAM
+    %% still carries a populated EEP-48 Docs chunk (moduledoc + foo/0 doc), so
+    %% ex_doc renders from the beam and the graceful-degradation path skips
+    %% edoc. Verified empirically on OTP 28: a backtick in a comment attached to
+    %% a *function* does NOT throw, but one attached to a *type* does.
+    io_lib:format(
+        "-module('~s').\n"
+        "-moduledoc \"\"\"\n"
+        "A module\n"
+        "\"\"\".\n"
+        "-export([foo/0]).\n"
+        "-export_type([t/0]).\n"
+        "-type s() :: integer().\n"
+        "%% a `backtick in this type comment\n"
+        "-type t() :: s().\n"
+        "-doc \"\"\"\n"
+        "foo/0 does nothing\n"
+        "\"\"\".\n"
+        "-spec foo() -> t().\n"
+        "foo() -> ok.\n",
+        [Name]
+    );
+erl_src_file(legacy_backtick_comment = _Variant, Name) ->
+    %% LEGACY (no -moduledoc/-doc) module hitting the SAME #123 edoc crash: a
+    %% Markdown backtick in a %% comment attached to a -type declaration makes
+    %% edoc:get_doc/2 throw. Unlike the native variant above, this module ships
+    %% NO populated EEP-48 Docs chunk (legacy @doc lives in comments, not in the
+    %% beam), so has_native_docs/1 returns false and gen_chunks/2 MUST still
+    %% abort via ?RAISE({gen_chunks, _}) exactly as before. This pins the
+    %% backward-compat contract: legacy projects fail fast on edoc errors, and
+    %% it also fails loudly (the abort assertion no longer holds) if a future
+    %% OTP changes edoc so the type-attached backtick stops throwing.
+    io_lib:format(
+        "%%% legacy module\n"
+        "-module('~s').\n"
+        "-export([foo/0]).\n"
+        "-export_type([t/0]).\n"
+        "-type s() :: integer().\n"
+        "%% a `backtick in this type comment\n"
+        "-type t() :: s().\n"
+        "%% @doc foo/0 does nothing\n"
+        "-spec foo() -> t().\n"
+        "foo() -> ok.\n",
+        [Name]
+    );
 erl_src_file(true = _Post27, Name) ->
     io_lib:format(
         "-module('~s').\n"


### PR DESCRIPTION
## Summary

Fixes [#123](https://github.com/jelly-beam/rebar3_ex_doc/issues/123) ("Crashes if type comment has backticks").

For a project documented with native OTP 27+ doc attributes (`-moduledoc` / `-doc`, EEP-59), `rebar3 ex_doc` currently aborts if a plain Markdown backtick (ASCII `0x60`) appears in an Erlang `%%` comment attached to a declaration (most commonly a type comment).

### Root cause

`gen_chunks/2` runs EDoc unconditionally with `{preprocess, true}, {doclet, edoc_doclet_chunks}`. EDoc parses every `%%` comment through its legacy wiki markup, where a backtick opens an inline-code span that must be closed by an apostrophe. A normal Markdown backtick has no closing apostrophe, so the wiki parser throws (`"`-quote ended unexpectedly at line N"`). `edoc_doclet_chunks` swallows the reason into `{'EXIT', error}`, and `gen_chunks/2` does `?RAISE({gen_chunks, Err})`, aborting the whole command **before `ex_doc` ever runs**.

The key observation: `ex_doc` reads documentation directly from the compiled BEAM's EEP-48 `Docs` chunk (it is handed the `ebin` dir), **not** from `doc/chunks/*.chunk`. So for native `-moduledoc`/`-doc` projects the EDoc step is effectively vestigial — its failure should not block doc generation.

I empirically verified the load-bearing assumptions on OTP 28.4.3:
- Running the bundled ex_doc escript against an `ebin` dir containing only a native beam + `.app` file, with **no** `doc/chunks` directory present, renders both the moduledoc and the function docs. So skipping EDoc for native projects loses no documentation.
- The EDoc chunks doclet only writes to `<dir>/chunks/*.chunk` and never patches the `ebin` `.beam`, so a `Docs` chunk in `ebin` for a clean build originates from native `-moduledoc`/`-doc`.
- A backtick in a comment attached to a **type** throws under `edoc:get_doc/2`, while the same comment attached to a function does not — matching the issue title precisely.

### What the fix does

In `gen_chunks/2`, the `{error, Err}` arm now checks whether the app's compiled beams carry a populated EEP-48 `Docs` chunk (`has_native_docs/1`):
- **Native docs present** → log the real EDoc error at `warn`, ensure the doc output dir exists (so `ex_doc` can write `docs.config`), and continue to `ex_doc`.
- **No native docs** (legacy `@doc` / undocumented apps that genuinely depend on EDoc) → `?RAISE({gen_chunks, Err})`, exactly as before.

`has_native_docs/1` reads each beam's `Docs` chunk via `beam_lib:chunks/3` with `allow_missing_chunks` and inspects the `docs_v1` term: a module doc and/or any entry doc that is a non-empty language map counts as populated. Modules with no `Docs` chunk (`missing_chunk`, an atom) or opt-out docs (`-moduledoc false` / `-doc false`, atom `hidden`/`none`) correctly yield `false`. Any `beam_lib`/`binary_to_term` error defensively yields `false`, so a malformed beam never masks a genuine EDoc failure for a legacy project.

Also tightened the `gen_chunks/2` spec (2nd arg is `rebar_app_info:t()`, not `file:filename()` — `run/2` always passes an app info and the body immediately calls `rebar_app_info:out_dir/1`).

### Why it is backward compatible

- The EDoc `{ok, State3}` success arm and everything downstream are byte-for-byte untouched, so any project where EDoc currently succeeds sees zero change.
- Legacy `@doc` / undocumented projects have no populated `Docs` chunk, so `has_native_docs/1` returns `false` and the identical `?RAISE` abort fires. I added a regression test that reproduces the same backtick crash on a legacy module and asserts it still aborts.
- `format_error/1`'s `{gen_chunks, Err}` clause is unchanged.
- No default flag flips; the behaviour change is scoped to apps that already ship native docs.

One scope note worth calling out explicitly: this graceful degradation applies to **any** EDoc failure for a native-docs app, not only the backtick crash. `ex_doc` still aborts on its own errors. I chose this because the EDoc step is genuinely redundant for native-docs projects, but I'm happy to narrow it (see below) if you prefer.

### How it was tested

- `rebar3 ct`: all 21 cases pass on OTP 28.4.3 (19 baseline + 2 new):
  - `generate_docs_native_docs_survive_edoc_backtick_crash` — native `-doc` module with a type-attached backtick comment; asserts `{ok, _}` and that the rendered HTML contains the doc text (red on the pre-fix `?RAISE`, green after).
  - `generate_docs_legacy_docs_still_abort_on_edoc_backtick_crash` — legacy `@doc` module with the **same** crash; asserts `?assertError({error, {rebar3_ex_doc, {gen_chunks, _}}}, ...)`. This locks down the backward-compat contract and also fails loudly if a future OTP changes EDoc so the type-attached backtick stops throwing (preventing the native test from silently passing via the EDoc-success arm).
- `rebar3 dialyzer`: clean, exit 0 (all new helpers are `-spec`'d).
- `rebar3 hank`: exit 0 (only pre-existing finding in the test suite + generated parsers in `deps/`).
- `rebar3 xref`: same local-environment behaviour as on `main` (rebar3's own modules are out of the local analysis scope here; the only added line is a call to `rebar_app_info:ebin_dir/1`, already called elsewhere in this module).

### A note on conventions

I could not find a `CONTRIBUTING` file or a CLA in the repo, so I made my best effort to match the existing style and keep the change minimal and surgical (the whole diff lives in the `gen_chunks/2` region plus a few private helpers, disjoint from the in-flight `bp/soft-deprecate-most-unsupported-ex-doc-options` branch). I'm 100% happy to follow whatever practices and conventions you prefer — squashing, commit message format, changelog wording, test placement, naming, etc. Just let me know.

I also read the discussion in #123: @eproxus suggested making EDoc opt-in (default to not building from EDoc, with a flag to enable it), and @paulo-ferraz-oliveira was rightly cautious that flipping the default could break the contract with existing installations (and suggested `{edoc_opts, [{preprocess, false}]}` as a workaround). This PR deliberately does **not** flip any default — it only degrades gracefully when native docs are already present in the beams, preserving the EDoc contract for everyone else. If you would rather express this as an explicit opt-in/opt-out flag, or narrow the trigger to only the backtick-class failure, I'm glad to adjust the approach. And it is totally fine if you consider this unnecessary — I'll defer to your judgement.

Thanks for maintaining this plugin!

Refs #123
